### PR TITLE
Add vibrant teal and orange accents

### DIFF
--- a/src/app/components/ProductCard.js
+++ b/src/app/components/ProductCard.js
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function ProductCard({ image, name, description, price }) {
   return (
-    <div className="border rounded-lg shadow p-4 flex flex-col items-center text-center">
+    <div className="border border-teal-200 rounded-lg shadow p-4 flex flex-col items-center text-center bg-white">
       <Image
         src={image}
         alt={name}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,9 +3,9 @@ import ProductCard from "./components/ProductCard";
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-white text-gray-800 font-sans">
+    <main className="min-h-screen bg-orange-50 text-gray-800 font-sans">
       {/* Header */}
-      <header className="flex justify-between items-center px-6 py-4 border-b shadow-sm">
+      <header className="flex justify-between items-center px-6 py-4 bg-teal-600 text-white shadow-md">
         <h1 className="text-2xl font-bold">PopUp Trinkets</h1>
         <nav className="space-x-4">
           <Link href="#shop" className="hover:underline">Shop</Link>
@@ -16,14 +16,19 @@ export default function Home() {
       </header>
 
       {/* Hero Section */}
-      <section className="text-center py-20 bg-amber-100">
+      <section className="text-center py-20 bg-gradient-to-r from-orange-200 via-pink-200 to-teal-200">
         <h2 className="text-4xl font-extrabold mb-4">Handmade Trinkets from the Heart</h2>
         <p className="text-lg text-gray-600 mb-6">One-of-a-kind finds, made with love and popping up near you.</p>
-        <a href="#shop" className="bg-amber-400 hover:bg-amber-500 text-white px-6 py-3 rounded-full font-semibold">See Products</a>
+        <a
+          href="#shop"
+          className="bg-orange-500 hover:bg-orange-600 text-white px-6 py-3 rounded-full font-semibold"
+        >
+          See Products
+        </a>
       </section>
 
       {/* Product Section */}
-      <section id="shop" className="py-16 px-6">
+      <section id="shop" className="py-16 px-6 bg-stone-50">
         <h3 className="text-3xl font-bold mb-8 text-center">Featured Items</h3>
         <div className="grid md:grid-cols-3 gap-8">
           {[
@@ -58,7 +63,7 @@ export default function Home() {
       </section>
 
       {/* Events Section */}
-      <section id="events" className="bg-gray-100 py-16 px-6">
+      <section id="events" className="bg-teal-50 py-16 px-6">
         <h3 className="text-3xl font-bold mb-6 text-center">Upcoming Pop-Ups</h3>
         <ul className="max-w-xl mx-auto space-y-4 text-center">
           <li>🌟 July 27 - Cleveland Flea Market</li>
@@ -68,7 +73,7 @@ export default function Home() {
       </section>
 
       {/* About Section */}
-      <section id="about" className="py-16 px-6">
+      <section id="about" className="py-16 px-6 bg-orange-50">
         <h3 className="text-3xl font-bold mb-4 text-center">Our Story</h3>
         <p className="max-w-2xl mx-auto text-center text-gray-700">
           PopUp Trinkets started as a weekend hobby and quickly grew into a traveling celebration of craft, color, and community. Every item is handmade, unique, and filled with personality.
@@ -76,7 +81,7 @@ export default function Home() {
       </section>
 
       {/* Contact Section */}
-      <section id="contact" className="bg-amber-100 py-16 px-6">
+      <section id="contact" className="bg-pink-100 py-16 px-6">
         <h3 className="text-3xl font-bold mb-4 text-center">Stay in Touch</h3>
         <p className="text-center text-gray-700 mb-6">Follow us on socials or email us at <a href="mailto:popuptrinkets@example.com" className="underline">popuptrinkets@example.com</a></p>
         <div className="text-center space-x-4">
@@ -86,7 +91,7 @@ export default function Home() {
       </section>
 
       {/* Footer */}
-      <footer className="text-center py-6 text-sm text-gray-500 border-t">
+      <footer className="text-center py-6 text-sm text-white bg-teal-600">
         © {new Date().getFullYear()} PopUp Trinkets. All rights reserved.
       </footer>
     </main>


### PR DESCRIPTION
## Summary
- brighten up header, hero, and sections with teal, orange, and pink
- accent product cards with teal borders

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688644aa9a788327974cd319e5a99935